### PR TITLE
questing works after changing scenes

### DIFF
--- a/OoO_Game/Assets/Prefabs/Portal.prefab
+++ b/OoO_Game/Assets/Prefabs/Portal.prefab
@@ -1,0 +1,139 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7107181812650872544
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 382986924415030041}
+  - component: {fileID: 8317049728430134058}
+  - component: {fileID: 1306661751063937270}
+  - component: {fileID: 1944262250547423041}
+  m_Layer: 0
+  m_Name: Portal
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &382986924415030041
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7107181812650872544}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: 0.99998695, w: 0.0051166723}
+  m_LocalPosition: {x: 13.5, y: 0.97, z: 0}
+  m_LocalScale: {x: 0.10607888, y: 0.21930435, z: 0.0522}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 179.414}
+--- !u!212 &8317049728430134058
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7107181812650872544}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -95882953
+  m_SortingLayer: 3
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 695689048c9d8b5408c8d1b998ab53bb, type: 3}
+  m_Color: {r: 0.3773585, g: 0.3574226, b: 0.3574226, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &1306661751063937270
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7107181812650872544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2dabad912f4727c47a36333d95747c1d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 0}
+  sceneName: Firing Range
+--- !u!70 &1944262250547423041
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7107181812650872544}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: -0.25929362, y: 2.2507184e-11}
+  m_Size: {x: 8.7808275, y: 20.480015}
+  m_Direction: 0

--- a/OoO_Game/Assets/Prefabs/Portal.prefab.meta
+++ b/OoO_Game/Assets/Prefabs/Portal.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 68fb24cce58b48445b86285e16cb44fa
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OoO_Game/Assets/Scenes/Firing Range.unity
+++ b/OoO_Game/Assets/Scenes/Firing Range.unity
@@ -11181,7 +11181,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -3.07
+      value: 2.31
       objectReference: {fileID: 0}
     - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
       propertyPath: m_LocalPosition.z

--- a/OoO_Game/Assets/Scenes/SpaceArea1.unity
+++ b/OoO_Game/Assets/Scenes/SpaceArea1.unity
@@ -130,7 +130,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -5.721598
+      value: -7
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalPosition.y
@@ -142,19 +142,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.0051166723
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.99998695
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -166,15 +166,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 179.414
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: player
       value: 
       objectReference: {fileID: 0}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: toScene
+      value: StartingBase
+      objectReference: {fileID: 0}
+    - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: sceneName
       value: StartingBase
+      objectReference: {fileID: 0}
+    - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: spawnOffsetX
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: zRotateOffset
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: connectingPortal
+      value: Leave Base Portal
       objectReference: {fileID: 0}
     - target: {fileID: 7107181812650872544, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_Name
@@ -486,7 +502,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.01974821, y: 0.9241607, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 5, y: 5, z: 5}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}

--- a/OoO_Game/Assets/Scenes/SpaceArea1.unity
+++ b/OoO_Game/Assets/Scenes/SpaceArea1.unity
@@ -1,0 +1,452 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &184168537
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3639852648816973544, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
+      propertyPath: m_Name
+      value: player
+      objectReference: {fileID: 0}
+    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.61
+      objectReference: {fileID: 0}
+    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70862526
+      objectReference: {fileID: 0}
+    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.000000008517451
+      objectReference: {fileID: 0}
+    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.000000024818055
+      objectReference: {fileID: 0}
+    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.705585
+      objectReference: {fileID: 0}
+    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -89.754
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
+--- !u!4 &184168538 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
+  m_PrefabInstance: {fileID: 184168537}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &184168539 stripped
+BoxCollider2D:
+  m_CorrespondingSourceObject: {fileID: 7354212513530949038, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
+  m_PrefabInstance: {fileID: 184168537}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &423044792
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.721598
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.088507414
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.0051166723
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.99998695
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 179.414
+      objectReference: {fileID: 0}
+    - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 184168539}
+    - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: sceneName
+      value: StartingBase
+      objectReference: {fileID: 0}
+    - target: {fileID: 7107181812650872544, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_Name
+      value: Back to Base Portal
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+--- !u!1 &794906874
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 794906877}
+  - component: {fileID: 794906876}
+  - component: {fileID: 794906875}
+  - component: {fileID: 794906878}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &794906875
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 794906874}
+  m_Enabled: 1
+--- !u!20 &794906876
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 794906874}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &794906877
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 794906874}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &794906878
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 794906874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c2e506fc64d879d4b9bfaddde1e98469, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  followTransform: {fileID: 184168538}
+--- !u!1 &1480663403
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1480663405}
+  - component: {fileID: 1480663404}
+  m_Layer: 0
+  m_Name: background1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1480663404
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1480663403}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 921c40fbf1338f9419f3823a92e4a267, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 20.48, y: 20.48}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1480663405
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1480663403}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.01974821, y: 0.9241607, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 794906877}
+  - {fileID: 184168537}
+  - {fileID: 1480663405}
+  - {fileID: 423044792}

--- a/OoO_Game/Assets/Scenes/SpaceArea1.unity
+++ b/OoO_Game/Assets/Scenes/SpaceArea1.unity
@@ -196,7 +196,7 @@ GameObject:
   - component: {fileID: 794906877}
   - component: {fileID: 794906876}
   - component: {fileID: 794906875}
-  - component: {fileID: 794906878}
+  - component: {fileID: 794906879}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -247,7 +247,7 @@ Camera:
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 5
+  orthographic size: 7.122097
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -272,13 +272,13 @@ Transform:
   m_GameObject: {fileID: 794906874}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalPosition: {x: -0.8043969, y: 0.47266296, z: -14.267456}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &794906878
+--- !u!114 &794906879
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -287,10 +287,126 @@ MonoBehaviour:
   m_GameObject: {fileID: 794906874}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c2e506fc64d879d4b9bfaddde1e98469, type: 3}
+  m_Script: {fileID: 11500000, guid: 72ece51f2901e7445ab60da3685d6b5f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  followTransform: {fileID: 0}
+  m_ShowDebugText: 0
+  m_ShowCameraFrustum: 1
+  m_IgnoreTimeScale: 0
+  m_WorldUpOverride: {fileID: 0}
+  m_UpdateMethod: 2
+  m_BlendUpdateMethod: 1
+  m_DefaultBlend:
+    m_Style: 1
+    m_Time: 2
+    m_CustomCurve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+  m_CustomBlends: {fileID: 0}
+  m_CameraCutEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CameraActivatedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &1244078785
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1244078786}
+  - component: {fileID: 1244078789}
+  - component: {fileID: 1244078788}
+  - component: {fileID: 1244078787}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1244078786
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1244078785}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1966989954}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1244078787
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1244078785}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fa7155796051b734daa718462081dc5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 1
+  m_FollowOffset: {x: 0, y: 0, z: -10}
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AngularDamping: 0
+--- !u!114 &1244078788
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1244078785}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0.5
+  m_VerticalDamping: 0.5
+  m_ScreenX: 0.5
+  m_ScreenY: 0.5
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &1244078789
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1244078785}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1480663403
 GameObject:
   m_ObjectHideFlags: 0
@@ -375,6 +491,91 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1966989952
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1966989954}
+  - component: {fileID: 1966989953}
+  - component: {fileID: 1966989955}
+  m_Layer: 0
+  m_Name: Virtual Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1966989953
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1966989952}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_Lens:
+    FieldOfView: 60
+    OrthographicSize: 7.122097
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    FocusDistance: 10
+    m_SensorSize: {x: 1, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 1244078786}
+--- !u!4 &1966989954
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1966989952}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.8043969, y: 0.47266296, z: -14.267456}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1244078786}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1966989955
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1966989952}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5fc9707aa4b18d49a1908f438fb166e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -382,3 +583,4 @@ SceneRoots:
   - {fileID: 794906877}
   - {fileID: 1480663405}
   - {fileID: 423044792}
+  - {fileID: 1966989954}

--- a/OoO_Game/Assets/Scenes/SpaceArea1.unity
+++ b/OoO_Game/Assets/Scenes/SpaceArea1.unity
@@ -120,73 +120,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &184168537
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 3639852648816973544, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_Name
-      value: player
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.61
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.70862526
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.000000008517451
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.000000024818055
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.705585
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -89.754
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
---- !u!4 &184168538 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-  m_PrefabInstance: {fileID: 184168537}
-  m_PrefabAsset: {fileID: 0}
---- !u!61 &184168539 stripped
-BoxCollider2D:
-  m_CorrespondingSourceObject: {fileID: 7354212513530949038, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-  m_PrefabInstance: {fileID: 184168537}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &423044792
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -238,7 +171,7 @@ PrefabInstance:
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: player
       value: 
-      objectReference: {fileID: 184168539}
+      objectReference: {fileID: 0}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: sceneName
       value: StartingBase
@@ -357,7 +290,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c2e506fc64d879d4b9bfaddde1e98469, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  followTransform: {fileID: 184168538}
+  followTransform: {fileID: 0}
 --- !u!1 &1480663403
 GameObject:
   m_ObjectHideFlags: 0
@@ -447,6 +380,5 @@ SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 794906877}
-  - {fileID: 184168537}
   - {fileID: 1480663405}
   - {fileID: 423044792}

--- a/OoO_Game/Assets/Scenes/SpaceArea1.unity.meta
+++ b/OoO_Game/Assets/Scenes/SpaceArea1.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 89f710005fa1ca147828641a139ba09a
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OoO_Game/Assets/Scenes/StartingBase.unity
+++ b/OoO_Game/Assets/Scenes/StartingBase.unity
@@ -5060,6 +5060,7 @@ GameObject:
   - component: {fileID: 519420032}
   - component: {fileID: 519420031}
   - component: {fileID: 519420033}
+  - component: {fileID: 519420036}
   - component: {fileID: 519420034}
   - component: {fileID: 519420035}
   m_Layer: 0
@@ -5194,6 +5195,34 @@ AudioListener:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   m_Enabled: 1
+--- !u!114 &519420036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e2eb713339f5b24aa29bca9b1c2538b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameEvent: {fileID: 11400000, guid: 629c67dc5e5aa2249a9227f56c4c3e18, type: 2}
+  response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 519420033}
+        m_TargetAssemblyTypeName: FollowPlayer, Assembly-CSharp
+        m_MethodName: OnLeaveCutscene
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &526201634
 GameObject:
   m_ObjectHideFlags: 0
@@ -10147,6 +10176,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3c82fc0c49ace844e9b25bada3517252, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  npcLoaded: {fileID: 11400000, guid: 622d40113d9ae7a4e88e768a777c1b37, type: 2}
   assignAQuest: {fileID: 11400000, guid: 1225bba9ee74eb2408a790822fe6104a, type: 2}
   questFinished: {fileID: 11400000, guid: 76e62528437ef1b4480a751a447fee75, type: 2}
   questStepTurnedIn: {fileID: 11400000, guid: d102fce4fdf384d4484285283a7b81a3, type: 2}
@@ -10562,11 +10592,11 @@ GameObject:
   - component: {fileID: 1367573263}
   - component: {fileID: 1367573265}
   - component: {fileID: 1367573264}
+  - component: {fileID: 1367573266}
   - component: {fileID: 1367573267}
   - component: {fileID: 1367573268}
   - component: {fileID: 1367573269}
   - component: {fileID: 1367573270}
-  - component: {fileID: 1367573266}
   m_Layer: 5
   m_Name: Michael Dialogue Panel
   m_TagString: Untagged
@@ -11729,6 +11759,7 @@ GameObject:
   - component: {fileID: 1059272156}
   - component: {fileID: 1059272165}
   - component: {fileID: 8877112659935457916}
+  - component: {fileID: 8877112659935457917}
   - component: {fileID: 2876792343909434295}
   - component: {fileID: 1059272161}
   m_Layer: 0
@@ -11932,6 +11963,34 @@ MonoBehaviour:
       - m_Target: {fileID: 3232407341315395836}
         m_TargetAssemblyTypeName: ship_movement, Assembly-CSharp
         m_MethodName: OnNpcZoneTriggered
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &8877112659935457917
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3639852649178913957}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e2eb713339f5b24aa29bca9b1c2538b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameEvent: {fileID: 11400000, guid: 629c67dc5e5aa2249a9227f56c4c3e18, type: 2}
+  response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3232407341315395836}
+        m_TargetAssemblyTypeName: ship_movement, Assembly-CSharp
+        m_MethodName: OnLeaveCutscene
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/OoO_Game/Assets/Scenes/StartingBase.unity
+++ b/OoO_Game/Assets/Scenes/StartingBase.unity
@@ -4893,9 +4893,10 @@ GameObject:
   - component: {fileID: 379417930}
   - component: {fileID: 379417929}
   - component: {fileID: 379417928}
+  - component: {fileID: 379417932}
   m_Layer: 5
   m_Name: Canvas
-  m_TagString: Untagged
+  m_TagString: Canvas
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -4984,6 +4985,18 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!114 &379417932
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 379417927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fff5982cff91653449e89b1ffe92b095, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &445827661
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10656,143 +10669,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1298843539}
   m_CullTransparentMesh: 1
---- !u!1 &1324915051
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1324915053}
-  - component: {fileID: 1324915052}
-  - component: {fileID: 1324915055}
-  - component: {fileID: 1324915056}
-  m_Layer: 0
-  m_Name: Leave Base Portal
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!212 &1324915052
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1324915051}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -95882953
-  m_SortingLayer: 3
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 695689048c9d8b5408c8d1b998ab53bb, type: 3}
-  m_Color: {r: 0.3773585, g: 0.3574226, b: 0.3574226, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &1324915053
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1324915051}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: 0.99998695, w: 0.0051166723}
-  m_LocalPosition: {x: 13.5, y: 0.97, z: 0}
-  m_LocalScale: {x: 0.10607888, y: 0.21930435, z: 0.0522}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 179.414}
---- !u!114 &1324915055
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1324915051}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2dabad912f4727c47a36333d95747c1d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  player: {fileID: 0}
-  sceneName: SampleScene
---- !u!70 &1324915056
-CapsuleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1324915051}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: -0.25929362, y: 2.2507184e-11}
-  m_Size: {x: 8.7808275, y: 20.480015}
-  m_Direction: 0
 --- !u!1 &1367573262
 GameObject:
   m_ObjectHideFlags: 0
@@ -11453,6 +11329,7 @@ GameObject:
   - component: {fileID: 2044437944}
   - component: {fileID: 2044437945}
   - component: {fileID: 2044437946}
+  - component: {fileID: 2044437947}
   m_Layer: 0
   m_Name: QuestManager
   m_TagString: Untagged
@@ -11602,6 +11479,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &2044437947
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2044437940}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fff5982cff91653449e89b1ffe92b095, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2047780383
 GameObject:
   m_ObjectHideFlags: 0
@@ -11918,6 +11807,71 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 13.5}
   m_SizeDelta: {x: 0, y: 27}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &5091400758243876266
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 13.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.0051166723
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.99998695
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 179.414
+      objectReference: {fileID: 0}
+    - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 1059272161}
+    - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: sceneName
+      value: SpaceArea1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7107181812650872544, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: m_Name
+      value: Leave Base Portal
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -11929,7 +11883,7 @@ SceneRoots:
   - {fileID: 828998933}
   - {fileID: 203613922}
   - {fileID: 2051525029}
-  - {fileID: 1324915053}
+  - {fileID: 5091400758243876266}
   - {fileID: 379417931}
   - {fileID: 1683131136}
   - {fileID: 1804283366}

--- a/OoO_Game/Assets/Scenes/StartingBase.unity
+++ b/OoO_Game/Assets/Scenes/StartingBase.unity
@@ -4844,7 +4844,7 @@ MonoBehaviour:
   onTriggerEnter:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1059272150}
+      - m_Target: {fileID: 3232407341315395836}
         m_TargetAssemblyTypeName: ship_movement, Assembly-CSharp
         m_MethodName: pauseMovement
         m_Mode: 1
@@ -4856,7 +4856,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 1059272150}
+      - m_Target: {fileID: 3232407341315395836}
         m_TargetAssemblyTypeName: ship_movement, Assembly-CSharp
         m_MethodName: faceNPC
         m_Mode: 1
@@ -4997,83 +4997,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fff5982cff91653449e89b1ffe92b095, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &445827661
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 3232407341222255281, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: npcTransform
-      value: 
-      objectReference: {fileID: 828998933}
-    - target: {fileID: 3639852648816973544, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_Name
-      value: player
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 2.69
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.57
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.99999994
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.00000002354322
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.000000011584456
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.00032022875
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -0.037
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 7354212513530949038, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-    - {fileID: 4635672200425468889, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3639852648816973544, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      insertIndex: 4
-      addedObject: {fileID: 1059272156}
-    - targetCorrespondingSourceObject: {fileID: 3639852648816973544, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      insertIndex: 5
-      addedObject: {fileID: 1059272165}
-    - targetCorrespondingSourceObject: {fileID: 3639852648816973544, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1059272161}
-  m_SourcePrefab: {fileID: 100100000, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
---- !u!1 &445827662 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3639852648816973544, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-  m_PrefabInstance: {fileID: 445827661}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &466518162
 GameObject:
   m_ObjectHideFlags: 0
@@ -5248,7 +5171,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fcc4ba0b5dc8cf74180c0718ea35467b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  player: {fileID: 1059272155}
+  player: {fileID: 6274131194088882875}
   npc: {fileID: 828998933}
   followFOV: 60
   cutsceneFOV: 30
@@ -10199,7 +10122,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c06e4ee2623ad4f40a5c89a917ac2cbc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerTransform: {fileID: 1059272155}
+  playerTransform: {fileID: 6274131194088882875}
 --- !u!70 &828998935
 CapsuleCollider2D:
   m_ObjectHideFlags: 0
@@ -10365,29 +10288,13 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
---- !u!114 &1059272150 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3232407341222255281, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-  m_PrefabInstance: {fileID: 445827661}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 445827662}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2529b37fbf33cf047b7740230da8b43a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &1059272155 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6274131194247334134, guid: d63d93b3c4b60b44997316df8f1a0292, type: 3}
-  m_PrefabInstance: {fileID: 445827661}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1059272156
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 445827662}
+  m_GameObject: {fileID: 3639852649178913957}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 96f474ef364b9e149a9758f133dec860, type: 3}
@@ -10400,7 +10307,7 @@ PolygonCollider2D:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 445827662}
+  m_GameObject: {fileID: 3639852649178913957}
   m_Enabled: 1
   serializedVersion: 3
   m_Density: 1
@@ -10462,7 +10369,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 445827662}
+  m_GameObject: {fileID: 3639852649178913957}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7e2eb713339f5b24aa29bca9b1c2538b, type: 3}
@@ -10767,7 +10674,7 @@ MonoBehaviour:
   onLeaveCutscene:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1059272150}
+      - m_Target: {fileID: 3232407341315395836}
         m_TargetAssemblyTypeName: ship_movement, Assembly-CSharp
         m_MethodName: unpauseMovement
         m_Mode: 1
@@ -11807,6 +11714,107 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 13.5}
   m_SizeDelta: {x: 0, y: 27}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2876792343909434295
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3639852649178913957}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Actions: {fileID: -944628639613478452, guid: 5af6c461f30ce69499768f3aea0b7e7d, type: 3}
+  m_NotificationBehavior: 0
+  m_UIInputModule: {fileID: 0}
+  m_DeviceLostEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_DeviceRegainedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ControlsChangedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ActionEvents: []
+  m_NeverAutoSwitchControlSchemes: 0
+  m_DefaultControlScheme: 
+  m_DefaultActionMap: Player
+  m_SplitScreenIndex: -1
+  m_Camera: {fileID: 0}
+--- !u!114 &3232407341315395836
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3639852649178913957}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2529b37fbf33cf047b7740230da8b43a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  npcTransform: {fileID: 828998933}
+  verticalInputAcceleration: 7
+  horizontalInputAcceleration: 300
+  maxSpeed: 100
+  maxRotationSpeed: 600
+  velocityDrag: 1.1
+  rotationDrag: 1.5
+  projectile: {fileID: 3011861483907594943, guid: 3efa307f0becb0148b7bb46d90f6f41b, type: 3}
+  cooldown: 0.5
+--- !u!1 &3639852649178913957
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6274131194088882875}
+  - component: {fileID: 8877112659935457915}
+  - component: {fileID: 4205724556577378619}
+  - component: {fileID: 3232407341315395836}
+  - component: {fileID: 1059272156}
+  - component: {fileID: 1059272165}
+  - component: {fileID: 2876792343909434295}
+  - component: {fileID: 1059272161}
+  m_Layer: 0
+  m_Name: player
+  m_TagString: Player
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!50 &4205724556577378619
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3639852649178913957}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
 --- !u!1001 &5091400758243876266
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11872,6 +11880,73 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+--- !u!4 &6274131194088882875
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3639852649178913957}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.00000002354322, y: -0.000000011584456, z: -0.00032022875, w: 0.99999994}
+  m_LocalPosition: {x: 2.69, y: -0.57, z: 0}
+  m_LocalScale: {x: 2.2610903, y: 2.1329463, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -0.037}
+--- !u!212 &8877112659935457915
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3639852649178913957}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1303663087
+  m_SortingLayer: 4
+  m_SortingOrder: 10
+  m_Sprite: {fileID: 21300000, guid: 8d5f697c999643441bb417d834c597de, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.31, y: 0.48}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -11879,7 +11954,7 @@ SceneRoots:
   - {fileID: 519420032}
   - {fileID: 1127781420}
   - {fileID: 2044437942}
-  - {fileID: 445827661}
+  - {fileID: 6274131194088882875}
   - {fileID: 828998933}
   - {fileID: 203613922}
   - {fileID: 2051525029}

--- a/OoO_Game/Assets/Scenes/StartingBase.unity
+++ b/OoO_Game/Assets/Scenes/StartingBase.unity
@@ -10035,6 +10035,7 @@ GameObject:
   - component: {fileID: 828998932}
   - component: {fileID: 828998935}
   - component: {fileID: 828998936}
+  - component: {fileID: 828998941}
   - component: {fileID: 828998938}
   - component: {fileID: 828998937}
   - component: {fileID: 828998940}
@@ -10284,6 +10285,34 @@ MonoBehaviour:
       - m_Target: {fileID: 828998936}
         m_TargetAssemblyTypeName: QuestGiver, Assembly-CSharp
         m_MethodName: OnQuestStepCompleted
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &828998941
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 828998931}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e2eb713339f5b24aa29bca9b1c2538b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameEvent: {fileID: 11400000, guid: defa12acb0b66f54393845740b8a2562, type: 2}
+  response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 828998936}
+        m_TargetAssemblyTypeName: QuestGiver, Assembly-CSharp
+        m_MethodName: OnSendQuestIds
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -11213,7 +11242,9 @@ GameObject:
   - component: {fileID: 2044437941}
   - component: {fileID: 2044437943}
   - component: {fileID: 2044437944}
+  - component: {fileID: 2044437948}
   - component: {fileID: 2044437945}
+  - component: {fileID: 2044437949}
   - component: {fileID: 2044437946}
   - component: {fileID: 2044437947}
   m_Layer: 0
@@ -11238,6 +11269,7 @@ MonoBehaviour:
   questBecomeReady: {fileID: 11400000, guid: fea242bedc88b444b8d6902cd45fded3, type: 2}
   questCanFinish: {fileID: 11400000, guid: ed6ca86b91a2f194bbdc34b89c6acf4a, type: 2}
   questFinalized: {fileID: 11400000, guid: be540f7de26fe644bbb4399503e2472f, type: 2}
+  sendQuestIds: {fileID: 11400000, guid: defa12acb0b66f54393845740b8a2562, type: 2}
 --- !u!4 &2044437942
 Transform:
   m_ObjectHideFlags: 0
@@ -11377,6 +11409,62 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fff5982cff91653449e89b1ffe92b095, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &2044437948
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2044437940}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e2eb713339f5b24aa29bca9b1c2538b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameEvent: {fileID: 11400000, guid: 622d40113d9ae7a4e88e768a777c1b37, type: 2}
+  response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2044437941}
+        m_TargetAssemblyTypeName: QuestManager, Assembly-CSharp
+        m_MethodName: OnNpcLoaded
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &2044437949
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2044437940}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e2eb713339f5b24aa29bca9b1c2538b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameEvent: {fileID: 11400000, guid: cc4ad0ef6ca909049a73059a41e6b3df, type: 2}
+  response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2044437941}
+        m_TargetAssemblyTypeName: QuestManager, Assembly-CSharp
+        m_MethodName: OnQuestStepCompleted
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &2047780383
 GameObject:
   m_ObjectHideFlags: 0

--- a/OoO_Game/Assets/Scenes/StartingBase.unity
+++ b/OoO_Game/Assets/Scenes/StartingBase.unity
@@ -4844,30 +4844,6 @@ MonoBehaviour:
   onTriggerEnter:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 3232407341315395836}
-        m_TargetAssemblyTypeName: ship_movement, Assembly-CSharp
-        m_MethodName: pauseMovement
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 3232407341315395836}
-        m_TargetAssemblyTypeName: ship_movement, Assembly-CSharp
-        m_MethodName: faceNPC
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 519420033}
         m_TargetAssemblyTypeName: FollowPlayer, Assembly-CSharp
         m_MethodName: npcInteractionZoom
@@ -5171,7 +5147,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fcc4ba0b5dc8cf74180c0718ea35467b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  player: {fileID: 6274131194088882875}
   npc: {fileID: 828998933}
   followFOV: 60
   cutsceneFOV: 30
@@ -10671,33 +10646,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   michaelTriggerZone: {fileID: 203613920}
-  onLeaveCutscene:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 3232407341315395836}
-        m_TargetAssemblyTypeName: ship_movement, Assembly-CSharp
-        m_MethodName: unpauseMovement
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 519420033}
-        m_TargetAssemblyTypeName: FollowPlayer, Assembly-CSharp
-        m_MethodName: outOfCutscene
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+  leaveCutscene: {fileID: 11400000, guid: 629c67dc5e5aa2249a9227f56c4c3e18, type: 2}
   secsBetweenCharsTyped: 0.1
 --- !u!114 &1367573267
 MonoBehaviour:
@@ -11779,6 +11728,7 @@ GameObject:
   - component: {fileID: 3232407341315395836}
   - component: {fileID: 1059272156}
   - component: {fileID: 1059272165}
+  - component: {fileID: 8877112659935457916}
   - component: {fileID: 2876792343909434295}
   - component: {fileID: 1059272161}
   m_Layer: 0
@@ -11837,19 +11787,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.0051166723
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.99998695
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -11861,15 +11811,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 179.414
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: player
       value: 
       objectReference: {fileID: 1059272161}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: toScene
+      value: SpaceArea1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: sceneName
       value: SpaceArea1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: spawnOffsetX
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: zRotateOffset
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
+      propertyPath: connectingPortal
+      value: Back to Base Portal
       objectReference: {fileID: 0}
     - target: {fileID: 7107181812650872544, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_Name
@@ -11947,6 +11913,34 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &8877112659935457916
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3639852649178913957}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e2eb713339f5b24aa29bca9b1c2538b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameEvent: {fileID: 11400000, guid: 5ec0d312aaaa23046a9d83c0f033f937, type: 2}
+  response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3232407341315395836}
+        m_TargetAssemblyTypeName: ship_movement, Assembly-CSharp
+        m_MethodName: OnNpcZoneTriggered
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/OoO_Game/Assets/Scripts/DontDestroy.cs
+++ b/OoO_Game/Assets/Scripts/DontDestroy.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DontDestroy : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        for(int i = 0; i < Object.FindObjectsOfType<DontDestroy>().Length; i++)
+        {
+            if (Object.FindObjectsOfType<DontDestroy>()[i] != this)
+            {
+                if (Object.FindObjectsOfType<DontDestroy>()[i].name == gameObject.name)
+                {
+                    Destroy(gameObject);
+                }
+            }
+        }
+
+        DontDestroyOnLoad(gameObject);
+    }
+    
+  }

--- a/OoO_Game/Assets/Scripts/DontDestroy.cs.meta
+++ b/OoO_Game/Assets/Scripts/DontDestroy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fff5982cff91653449e89b1ffe92b095
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OoO_Game/Assets/Scripts/Events/LeaveCutscene.asset
+++ b/OoO_Game/Assets/Scripts/Events/LeaveCutscene.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c402a1d0664bc54a9c5308b61463be7, type: 3}
+  m_Name: LeaveCutscene
+  m_EditorClassIdentifier: 
+  listeners: []

--- a/OoO_Game/Assets/Scripts/Events/LeaveCutscene.asset.meta
+++ b/OoO_Game/Assets/Scripts/Events/LeaveCutscene.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 629c67dc5e5aa2249a9227f56c4c3e18
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OoO_Game/Assets/Scripts/Events/NpcLoaded.asset
+++ b/OoO_Game/Assets/Scripts/Events/NpcLoaded.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c402a1d0664bc54a9c5308b61463be7, type: 3}
+  m_Name: NpcLoaded
+  m_EditorClassIdentifier: 
+  listeners: []

--- a/OoO_Game/Assets/Scripts/Events/NpcLoaded.asset.meta
+++ b/OoO_Game/Assets/Scripts/Events/NpcLoaded.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 622d40113d9ae7a4e88e768a777c1b37
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OoO_Game/Assets/Scripts/Events/QuestCanFinish.asset
+++ b/OoO_Game/Assets/Scripts/Events/QuestCanFinish.asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 0}
+  m_Script: {fileID: 11500000, guid: 5c402a1d0664bc54a9c5308b61463be7, type: 3}
   m_Name: QuestCanFinish
   m_EditorClassIdentifier: Assembly-CSharp::GameEvent
   listeners: []

--- a/OoO_Game/Assets/Scripts/Events/SendQuestIDs.asset
+++ b/OoO_Game/Assets/Scripts/Events/SendQuestIDs.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c402a1d0664bc54a9c5308b61463be7, type: 3}
+  m_Name: SendQuestIDs
+  m_EditorClassIdentifier: 
+  listeners: []

--- a/OoO_Game/Assets/Scripts/Events/SendQuestIDs.asset.meta
+++ b/OoO_Game/Assets/Scripts/Events/SendQuestIDs.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: defa12acb0b66f54393845740b8a2562
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OoO_Game/Assets/Scripts/MichaelDialoguePanel.cs
+++ b/OoO_Game/Assets/Scripts/MichaelDialoguePanel.cs
@@ -7,7 +7,9 @@ using TMPro;
 public class MichaelDialoguePanel : MonoBehaviour
 {
     public GameObject michaelTriggerZone;
-    public UnityEvent onLeaveCutscene;
+
+    [SerializeField]
+    private GameEvent leaveCutscene;
 
     private TextMeshProUGUI dialogueTM;
     public float secsBetweenCharsTyped;
@@ -110,7 +112,9 @@ public class MichaelDialoguePanel : MonoBehaviour
             }
         }
         dialogueTM.text = "";
-        onLeaveCutscene.Invoke(); // do actions to make cutscene end
+
+        leaveCutscene.Raise();
+
         gameObject.SetActive(false); //make michael dialogue panel not show/run
     } 
     

--- a/OoO_Game/Assets/Scripts/MichaelDialoguePanel.cs
+++ b/OoO_Game/Assets/Scripts/MichaelDialoguePanel.cs
@@ -57,6 +57,7 @@ public class MichaelDialoguePanel : MonoBehaviour
 
     public void OnNpcNothingToDo(Component sender, object data)
     {
+        Debug.Log("inside onnpcnothingtodo");
         linesToSay = linesDoNothing;
         startDialogue();
     }

--- a/OoO_Game/Assets/Scripts/PlayerInfo.cs
+++ b/OoO_Game/Assets/Scripts/PlayerInfo.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class PlayerInfo : MonoBehaviour
 {
-    private static PlayerInfo playerInstance;
+    public static PlayerInfo playerInstance;
 
     public GameEvent playerLevelChanged;
 

--- a/OoO_Game/Assets/Scripts/PlayerInfo.cs
+++ b/OoO_Game/Assets/Scripts/PlayerInfo.cs
@@ -4,9 +4,24 @@ using UnityEngine;
 
 public class PlayerInfo : MonoBehaviour
 {
+    private static PlayerInfo playerInstance;
+
     public GameEvent playerLevelChanged;
 
     private int playerLevel;
+
+    private void Awake()
+    {
+        if(playerInstance == null)
+        {
+            playerInstance = this;
+            DontDestroyOnLoad(this.gameObject);
+        }
+        else
+        {
+            Destroy(this.gameObject);
+        }
+    }
 
     private void Start()
     {

--- a/OoO_Game/Assets/Scripts/Quest System/QuestGiver.cs
+++ b/OoO_Game/Assets/Scripts/Quest System/QuestGiver.cs
@@ -18,7 +18,7 @@ public class QuestGiver : MonoBehaviour
 
     private void Start()
     {
-        npcLoaded.Raise(); //notify quest manager to send quest ids
+        npcLoaded.Raise(); //notify quest manager to send quest ids for init lists
     }
 
     public void onQuestBecomeReady(Component sender, object data)
@@ -30,6 +30,18 @@ public class QuestGiver : MonoBehaviour
             {
                 canStartQuestIds.Add(newCanStartQuestId);
             }
+        }
+    }
+
+    public void OnSendQuestIds(Component sender, object data)
+    {
+        QuestManager qMan = sender as QuestManager;
+
+        if(qMan != null)
+        {
+            canStartQuestIds = qMan.GetQuestIdsWithState(QuestState.CAN_START);
+            questStepCanBeTurnedInIds = qMan.GetQuestIdsWithState(QuestState.STEP_DONE);
+            canFinishQuestIds = qMan.GetQuestIdsWithState(QuestState.CAN_FINISH);
         }
     }
 

--- a/OoO_Game/Assets/Scripts/Quest System/QuestGiver.cs
+++ b/OoO_Game/Assets/Scripts/Quest System/QuestGiver.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 
 public class QuestGiver : MonoBehaviour
 {
+    [SerializeField]
+    private GameEvent npcLoaded;
     public GameEvent assignAQuest;
     public GameEvent questFinished;
     public GameEvent questStepTurnedIn;
@@ -13,6 +15,11 @@ public class QuestGiver : MonoBehaviour
     private List<string> questStepCanBeTurnedInIds = new List<string>();
     private List<string> canFinishQuestIds = new List<string>();
     private int questsActive = 0;
+
+    private void Start()
+    {
+        npcLoaded.Raise(); //notify quest manager to send quest ids
+    }
 
     public void onQuestBecomeReady(Component sender, object data)
     {

--- a/OoO_Game/Assets/Scripts/Quest System/QuestManager.cs
+++ b/OoO_Game/Assets/Scripts/Quest System/QuestManager.cs
@@ -20,6 +20,7 @@ public class QuestManager : MonoBehaviour
     public void onPlayerLevelChanged(Component sender, object data)
     {
         if (data is int) currentPlayerLevel = (int)data; //update the current player level
+        Debug.Log("player level changed to " + currentPlayerLevel);
         //check if any quests meet can now be started at the new level and set them as CAN_START
         foreach(Quest quest in questMap.Values)
         {

--- a/OoO_Game/Assets/Scripts/Quest System/QuestManager.cs
+++ b/OoO_Game/Assets/Scripts/Quest System/QuestManager.cs
@@ -7,6 +7,8 @@ public class QuestManager : MonoBehaviour
     public GameEvent questBecomeReady;
     public GameEvent questCanFinish;
     public GameEvent questFinalized;
+    [SerializeField]
+    private GameEvent sendQuestIds;
 
     private Dictionary<string, Quest> questMap;
 
@@ -19,7 +21,7 @@ public class QuestManager : MonoBehaviour
 
     public void OnNpcLoaded(Component sender, object data)
     {
-        
+        sendQuestIds.Raise(this); 
     }
 
     public void onPlayerLevelChanged(Component sender, object data)
@@ -82,6 +84,16 @@ public class QuestManager : MonoBehaviour
         }
     }
 
+    public void OnQuestStepCompleted(Component sender, object data)
+    {
+        if(data is string)
+        {
+            string questId = (string)data;
+
+            ChangeQuestState(questId, QuestState.STEP_DONE);
+        }
+    }
+
     private void AdvanceQuest(string id)
     {
         Quest quest = GetQuestById(id);
@@ -90,6 +102,8 @@ public class QuestManager : MonoBehaviour
 
         if (quest.CurrentStepExists())
         {
+            ChangeQuestState(id, QuestState.IN_PROGRESS); // STEP_DONE -> IN_PROGRESS
+
             quest.InstantiateCurrentQuestStep(this.transform);
         }
         else //all quest steps completed
@@ -134,5 +148,20 @@ public class QuestManager : MonoBehaviour
             Debug.LogError("Quest with id not found: " + id);
         }
         return questRequested;
+    }
+
+    public List<string> GetQuestIdsWithState(QuestState stateToFind) 
+    {
+        List<string> questIds = new List<string>();
+
+        foreach(var questPair in questMap)
+        {
+            if(questPair.Value.state == stateToFind)
+            {
+                questIds.Add(questPair.Key);
+            }
+        }
+
+        return questIds;
     }
 }

--- a/OoO_Game/Assets/Scripts/Quest System/QuestManager.cs
+++ b/OoO_Game/Assets/Scripts/Quest System/QuestManager.cs
@@ -17,6 +17,11 @@ public class QuestManager : MonoBehaviour
         questMap = CreateQuestMap(); 
     }
 
+    public void OnNpcLoaded(Component sender, object data)
+    {
+        
+    }
+
     public void onPlayerLevelChanged(Component sender, object data)
     {
         if (data is int) currentPlayerLevel = (int)data; //update the current player level

--- a/OoO_Game/Assets/Scripts/Quest System/QuestState.cs
+++ b/OoO_Game/Assets/Scripts/Quest System/QuestState.cs
@@ -7,6 +7,7 @@ public enum QuestState
     REQUIREMENTS_NOT_MET,
     CAN_START,
     IN_PROGRESS,
+    STEP_DONE,
     CAN_FINISH,
     FINISHED
 }

--- a/OoO_Game/Assets/Scripts/Triggers/LeaveBaseZone.cs
+++ b/OoO_Game/Assets/Scripts/Triggers/LeaveBaseZone.cs
@@ -5,19 +5,46 @@ using UnityEngine;
 
 public class LeaveBaseZone : MonoBehaviour
 {
-    public string sceneName;
+    [SerializeField]
+    private string toScene;
+    [SerializeField]
+    private string connectingPortal;
+    [SerializeField]
+    private float spawnOffsetY;
+    [SerializeField]
+    private float spawnOffsetX;
+    [SerializeField]
+    private float zRotateOffset;
+
+    private void Start()
+    {
+        //if prev portal connects to this portal then spawn player near this portal
+        if(PlayerPrefs.GetString("LastUsedPortal") == connectingPortal)
+        {
+            //player position
+            PlayerInfo.playerInstance.transform.position =
+                new Vector3(transform.position.x + spawnOffsetX, transform.position.y + spawnOffsetY);
+
+            //player rotation
+            PlayerInfo.playerInstance.transform.eulerAngles = 
+                new Vector3(transform.eulerAngles.x, transform.eulerAngles.y, transform.eulerAngles.z + zRotateOffset);
+        }
+    }
 
     private void OnTriggerStay2D(Collider2D collision)
     {
         if(collision.CompareTag("Player"))
         {
-            SceneManager.LoadScene(sceneName);
+            //save portal name so can correctly place player in next scene
+            PlayerPrefs.SetString("LastUsedPortal", gameObject.name);
+
+            SceneManager.LoadScene(toScene);
         }
     }
 
     public void changeSceneToLoad(string newSceneName)
     {
-        sceneName = newSceneName;
+        toScene = newSceneName;
     }
 
 }

--- a/OoO_Game/Assets/Scripts/Triggers/LeaveBaseZone.cs
+++ b/OoO_Game/Assets/Scripts/Triggers/LeaveBaseZone.cs
@@ -5,12 +5,11 @@ using UnityEngine;
 
 public class LeaveBaseZone : MonoBehaviour
 {
-    public Collider2D player;
     public string sceneName;
 
     private void OnTriggerStay2D(Collider2D collision)
     {
-        if(collision == player)
+        if(collision.CompareTag("Player"))
         {
             SceneManager.LoadScene(sceneName);
         }

--- a/OoO_Game/Assets/Scripts/Triggers/SimpleTrigger.cs
+++ b/OoO_Game/Assets/Scripts/Triggers/SimpleTrigger.cs
@@ -6,7 +6,23 @@ public class SimpleTrigger : MonoBehaviour
 
     public GameEvent npcZoneTriggered;
     public UnityEvent onTriggerEnter;
-    public GameObject michaelDialoguePanel;
+
+    [SerializeField]
+    private GameObject michaelDialoguePanel;
+
+    private void Start()
+    {
+        GameObject canvas = GameObject.FindGameObjectWithTag("Canvas");
+
+        if(canvas != null)
+        {
+            michaelDialoguePanel = canvas.transform.Find("Michael Dialogue Panel").gameObject;
+        }
+        else
+        {
+            Debug.Log("npc zone couldnt find canvas inside simple trigger script.");
+        }
+    }
 
 
     void OnTriggerEnter2D(Collider2D other)

--- a/OoO_Game/Assets/Scripts/camera/CameraMovement.cs
+++ b/OoO_Game/Assets/Scripts/camera/CameraMovement.cs
@@ -6,8 +6,9 @@ public class FollowPlayer : MonoBehaviour
 {
     private Camera cam;
 
-    public Transform player;
     public Transform npc;
+
+    private Transform player;
     
     private Vector3 targetCamPos;
     private Vector3 camPosOnEnter;
@@ -21,6 +22,9 @@ public class FollowPlayer : MonoBehaviour
 
     private void Start()
     {
+        //intitialize the player transform for camera follow capability
+        player = GameObject.FindGameObjectWithTag("Player").transform;
+
         cam = GetComponent<Camera>();
     }
 
@@ -45,6 +49,11 @@ public class FollowPlayer : MonoBehaviour
                 transform.position = newCamPos;
             }
         }
+    }
+
+    public void OnLeaveCutscene(Component sender, object data)
+    {
+        outOfCutscene();
     }
 
     public void outOfCutscene()

--- a/OoO_Game/Assets/Scripts/player/ship_movement.cs
+++ b/OoO_Game/Assets/Scripts/player/ship_movement.cs
@@ -84,6 +84,17 @@ public class ship_movement : MonoBehaviour
 
     }
 
+    public void OnNpcZoneTriggered(Component sender, object data)
+    {
+        pauseMovement();
+        faceNPC();
+    }
+
+    public void OnLeaveCutscene(Component sender, object data)
+    {
+        unpauseMovement();
+    }
+
     public void unpauseMovement()
     {
         verticalInputAcceleration = oldVertAccel;
@@ -93,7 +104,7 @@ public class ship_movement : MonoBehaviour
         oldHorizAccel = 0;
     }
 
-    public void pauseMovement()
+    private void pauseMovement()
     {
         velocity = velocity / 5;
         zRotationVelocity = 0;
@@ -107,7 +118,7 @@ public class ship_movement : MonoBehaviour
         horizontalInputAcceleration = 0;
     }
 
-    public void faceNPC()
+    private void faceNPC()
     {
         if (npcTransform != null)
         {

--- a/OoO_Game/Assets/Scripts/player/ship_movement.cs
+++ b/OoO_Game/Assets/Scripts/player/ship_movement.cs
@@ -95,7 +95,7 @@ public class ship_movement : MonoBehaviour
 
     public void pauseMovement()
     {
-        velocity = velocity / 10;
+        velocity = velocity / 5;
         zRotationVelocity = 0;
 
         // save old accel settings

--- a/OoO_Game/Assets/VirtualCamController.cs
+++ b/OoO_Game/Assets/VirtualCamController.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Cinemachine;
+
+public class VirtualCamController : MonoBehaviour
+{
+    private Transform playerFollowTarget;
+
+    private CinemachineVirtualCamera virtualCam;
+
+    void Start()
+    {
+        virtualCam = GetComponent<CinemachineVirtualCamera>();
+
+        playerFollowTarget = GameObject.FindGameObjectWithTag("Player").transform;
+
+        if(playerFollowTarget != null)
+        {
+            virtualCam.Follow = playerFollowTarget;
+            virtualCam.LookAt = playerFollowTarget;
+        }
+    }
+
+}

--- a/OoO_Game/Assets/VirtualCamController.cs.meta
+++ b/OoO_Game/Assets/VirtualCamController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5fc9707aa4b18d49a1908f438fb166e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OoO_Game/ProjectSettings/EditorBuildSettings.asset
+++ b/OoO_Game/ProjectSettings/EditorBuildSettings.asset
@@ -17,5 +17,14 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/DeathMenu.unity
     guid: 4043dff336598204d82c9e780673108b
+  - enabled: 1
+    path: Assets/Scenes/SampleScene.unity
+    guid: 2cda990e2423bbf4892e6590ba056729
+  - enabled: 1
+    path: Assets/Scenes/Firing Range.unity
+    guid: 68a97a5470ee3124380805cf62c349ea
+  - enabled: 1
+    path: Assets/Scenes/SpaceArea1.unity
+    guid: 89f710005fa1ca147828641a139ba09a
   m_configObjects: {}
   m_UseUCBPForAssetBundles: 0

--- a/OoO_Game/ProjectSettings/TagManager.asset
+++ b/OoO_Game/ProjectSettings/TagManager.asset
@@ -7,6 +7,7 @@ TagManager:
   - Projectile
   - enemy
   - enemyProjectile
+  - Canvas
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Made some gameobjects persist between scenes so doesnt lose game state:

- playerinfo on player uses singleton and dontdestroyonload so the one player persists between scenes so can keep track of player level and other info. Using a single player instead of seperate player prefabs in each scene makes more sense because keeping track of player information is more straightforward

- questmanager uses dontdestroyonload and is taken with player to other scenes. Quest step prefabs are a child of questmanager so they also wont be destroyed, so you can complete a quest step in another scene then go back to base and turn it in.

- questgiver (npc) isnt taken to other scenes so the quest lists it keeps track of will be lost on scene switches. Thus, in the start method of questgiver script it will notify questmanager to send the quest ids so the quest lists can be reinitialized with the correct ids. That way questgiver doesnt have to persist between scenes and can just stay in startingbase scene.