### PR TITLE
add kill enemies quest, tweaked portals and npc

### DIFF
--- a/OoO_Game/Assets/Resources/Quests/KillEnemiesLevel1.meta
+++ b/OoO_Game/Assets/Resources/Quests/KillEnemiesLevel1.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0cab4113a9ff09249b2cfd887a027377
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OoO_Game/Assets/Resources/Quests/KillEnemiesLevel1/KillEnemies.asset
+++ b/OoO_Game/Assets/Resources/Quests/KillEnemiesLevel1/KillEnemies.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4859f58b345ac1f4494e1a67bb9c008e, type: 3}
+  m_Name: KillEnemies
+  m_EditorClassIdentifier: 
+  <id>k__BackingField: KillEnemies
+  displayName: Kill Enemies
+  finishedLines:
+  - Thanks for killing all those enemies! You've made this area more inhabitable.
+  playerLevelRequired: 1
+  questStepPrefabs:
+  - {fileID: 3851210575435135148, guid: 6a9b571825f12b5489ca44b31acf30a0, type: 3}

--- a/OoO_Game/Assets/Resources/Quests/KillEnemiesLevel1/KillEnemies.asset.meta
+++ b/OoO_Game/Assets/Resources/Quests/KillEnemiesLevel1/KillEnemies.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 04fc05908dac9ba49a3c6c44f125975f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OoO_Game/Assets/Resources/Quests/KillEnemiesLevel1/KillEnemiesQuestStep.cs
+++ b/OoO_Game/Assets/Resources/Quests/KillEnemiesLevel1/KillEnemiesQuestStep.cs
@@ -1,0 +1,17 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class KillEnemiesQuestStep : QuestStep
+{
+    private int numberOfEnemiesKilled = 0;
+
+    public void OnEnemyKilled(Component sender, object data)
+    {
+        ++numberOfEnemiesKilled;
+        if(numberOfEnemiesKilled >= 5)
+        {
+            FinishQuestStep();
+        }
+    }
+}

--- a/OoO_Game/Assets/Resources/Quests/KillEnemiesLevel1/KillEnemiesQuestStep.cs.meta
+++ b/OoO_Game/Assets/Resources/Quests/KillEnemiesLevel1/KillEnemiesQuestStep.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea5776e8524ee004599fb26ca9ecb097
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OoO_Game/Assets/Resources/Quests/KillEnemiesLevel1/KillEnemiesQuestStep.prefab
+++ b/OoO_Game/Assets/Resources/Quests/KillEnemiesLevel1/KillEnemiesQuestStep.prefab
@@ -1,0 +1,82 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3851210575435135148
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5023167911178604592}
+  - component: {fileID: -6762303569252984054}
+  - component: {fileID: -5155178293413050227}
+  m_Layer: 0
+  m_Name: KillEnemiesQuestStep
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5023167911178604592
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3851210575435135148}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-6762303569252984054
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3851210575435135148}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea5776e8524ee004599fb26ca9ecb097, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  questStepCompleted: {fileID: 11400000, guid: cc4ad0ef6ca909049a73059a41e6b3df, type: 2}
+  questStepStarted: {fileID: 11400000, guid: 2cac9691d7ddea341a0f447627c777c4, type: 2}
+  description: Kill 5 Enemies
+  stepDialogueLines:
+  - So, now for the real work...
+  - There's been an invasion of enemy ships just outside this base.
+  - Travel through that portal over there and see if you can kill five of them.
+--- !u!114 &-5155178293413050227
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3851210575435135148}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e2eb713339f5b24aa29bca9b1c2538b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameEvent: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
+  response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: -6762303569252984054}
+        m_TargetAssemblyTypeName: KillEnemiesQuestStep, Assembly-CSharp
+        m_MethodName: OnEnemyKilled
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2

--- a/OoO_Game/Assets/Resources/Quests/KillEnemiesLevel1/KillEnemiesQuestStep.prefab.meta
+++ b/OoO_Game/Assets/Resources/Quests/KillEnemiesLevel1/KillEnemiesQuestStep.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6a9b571825f12b5489ca44b31acf30a0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OoO_Game/Assets/Scenes/Level1.unity
+++ b/OoO_Game/Assets/Scenes/Level1.unity
@@ -380,7 +380,6 @@ GameObject:
   m_Component:
   - component: {fileID: 201801216}
   - component: {fileID: 201801215}
-  - component: {fileID: 201801217}
   m_Layer: 0
   m_Name: Grid
   m_TagString: Untagged
@@ -417,20 +416,6 @@ Transform:
   - {fileID: 1689901302}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &201801217
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 201801214}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a8de3ee976c14f84b980a8fc0202d876, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  player: {fileID: 0}
-  triggerLocation: {fileID: 0}
 --- !u!1 &409241988
 GameObject:
   m_ObjectHideFlags: 0
@@ -832,6 +817,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5488776387778068154, guid: cff5b7220554282488d4ac783aa7b45c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
+    - target: {fileID: 5488776387778068154, guid: cff5b7220554282488d4ac783aa7b45c, type: 3}
       propertyPath: nonStopShooting
       value: 1
       objectReference: {fileID: 0}
@@ -970,6 +959,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: advanced_enemy (3)
       objectReference: {fileID: 0}
+    - target: {fileID: 7704964364191713298, guid: 6ce3af11de254d0449bef17bea89f54c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1295,6 +1288,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: advanced_enemy (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 7704964364191713298, guid: 6ce3af11de254d0449bef17bea89f54c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1318,7 +1315,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 75.48
+      value: 75.17
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalPosition.y
@@ -1362,7 +1359,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: spawnOffsetX
-      value: -1
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: zRotateOffset
@@ -1490,11 +1487,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: toScene
-      value: Level0
+      value: StartingBase
       objectReference: {fileID: 0}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: spawnOffsetX
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: zRotateOffset
@@ -1502,11 +1499,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: connectingPortal
-      value: Level1 Portal
+      value: Leave Base Portal
       objectReference: {fileID: 0}
     - target: {fileID: 7107181812650872544, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_Name
-      value: Back to Level0 Portal
+      value: Back to Starting Base
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1702,6 +1699,10 @@ PrefabInstance:
       propertyPath: canPatrol
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5488776387778068154, guid: cff5b7220554282488d4ac783aa7b45c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -123665,6 +123666,10 @@ PrefabInstance:
       propertyPath: canPatrol
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7704964364191713298, guid: 6ce3af11de254d0449bef17bea89f54c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -123726,6 +123731,10 @@ PrefabInstance:
       propertyPath: canShoot
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7704964364191713298, guid: 6ce3af11de254d0449bef17bea89f54c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
     - target: {fileID: 7704964364191713298, guid: 6ce3af11de254d0449bef17bea89f54c, type: 3}
       propertyPath: patrolMode_UpDown
       value: 0

--- a/OoO_Game/Assets/Scenes/Level2.unity
+++ b/OoO_Game/Assets/Scenes/Level2.unity
@@ -172,6 +172,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: basic_enemy (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 5488776387778068154, guid: cff5b7220554282488d4ac783aa7b45c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -229,6 +233,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: advanced_enemy (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 7704964364191713298, guid: 6ce3af11de254d0449bef17bea89f54c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -286,6 +294,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: basic_enemy (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 5488776387778068154, guid: cff5b7220554282488d4ac783aa7b45c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -301,7 +313,6 @@ GameObject:
   m_Component:
   - component: {fileID: 201801216}
   - component: {fileID: 201801215}
-  - component: {fileID: 201801217}
   m_Layer: 0
   m_Name: Grid
   m_TagString: Untagged
@@ -338,20 +349,6 @@ Transform:
   - {fileID: 1689901302}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &201801217
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 201801214}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a8de3ee976c14f84b980a8fc0202d876, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  player: {fileID: 0}
-  triggerLocation: {fileID: 1323040387}
 --- !u!1001 &482437717
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -611,6 +608,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: advanced_enemy (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 7704964364191713298, guid: 6ce3af11de254d0449bef17bea89f54c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -668,6 +669,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: basic_enemy
       objectReference: {fileID: 0}
+    - target: {fileID: 5488776387778068154, guid: cff5b7220554282488d4ac783aa7b45c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -725,6 +730,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: advanced_enemy
       objectReference: {fileID: 0}
+    - target: {fileID: 7704964364191713298, guid: 6ce3af11de254d0449bef17bea89f54c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -748,11 +757,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -10.39
+      value: -9.7
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -3.44
+      value: -3.45
       objectReference: {fileID: 0}
     - target: {fileID: 382986924415030041, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_LocalPosition.z
@@ -863,6 +872,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: basic_enemy (5)
       objectReference: {fileID: 0}
+    - target: {fileID: 5488776387778068154, guid: cff5b7220554282488d4ac783aa7b45c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1329,6 +1342,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: advanced_enemy (3)
       objectReference: {fileID: 0}
+    - target: {fileID: 7704964364191713298, guid: 6ce3af11de254d0449bef17bea89f54c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1520,6 +1537,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: basic_enemy (4)
       objectReference: {fileID: 0}
+    - target: {fileID: 5488776387778068154, guid: cff5b7220554282488d4ac783aa7b45c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -129066,6 +129087,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: basic_enemy (3)
       objectReference: {fileID: 0}
+    - target: {fileID: 5488776387778068154, guid: cff5b7220554282488d4ac783aa7b45c, type: 3}
+      propertyPath: enemyKilled
+      value: 
+      objectReference: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/OoO_Game/Assets/Scenes/StartingBase.unity
+++ b/OoO_Game/Assets/Scenes/StartingBase.unity
@@ -5925,7 +5925,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 148.4, y: -58.4}
+  m_AnchoredPosition: {x: 148.4, y: -58.399994}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &624300691
@@ -13306,7 +13306,7 @@ PrefabInstance:
       objectReference: {fileID: 1059272161}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: toScene
-      value: Level0
+      value: Level1
       objectReference: {fileID: 0}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: sceneName
@@ -13314,7 +13314,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: spawnOffsetX
-      value: -1
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: zRotateOffset
@@ -13322,7 +13322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1306661751063937270, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: connectingPortal
-      value: Back to Base Portal
+      value: Back to Starting Base
       objectReference: {fileID: 0}
     - target: {fileID: 7107181812650872544, guid: 68fb24cce58b48445b86285e16cb44fa, type: 3}
       propertyPath: m_Name

--- a/OoO_Game/Assets/Scripts/Events/EnemyKilled.asset
+++ b/OoO_Game/Assets/Scripts/Events/EnemyKilled.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c402a1d0664bc54a9c5308b61463be7, type: 3}
+  m_Name: EnemyKilled
+  m_EditorClassIdentifier: 
+  listeners: []

--- a/OoO_Game/Assets/Scripts/Events/EnemyKilled.asset.meta
+++ b/OoO_Game/Assets/Scripts/Events/EnemyKilled.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 714d4b3917f70ca48a66301973682efe
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OoO_Game/Assets/Scripts/MichaelDialoguePanel.cs
+++ b/OoO_Game/Assets/Scripts/MichaelDialoguePanel.cs
@@ -19,6 +19,7 @@ public class MichaelDialoguePanel : MonoBehaviour
     private List<string> linesDoNothing = new List<string>();
 
     private bool skippedDialogue = false;
+    private bool inDialogue = false;
 
     //called when script is loaded (at game start)
     private void Awake()
@@ -45,6 +46,7 @@ public class MichaelDialoguePanel : MonoBehaviour
     {
         if(data is List<string>)
         {
+            inDialogue = true;
             linesPrevSaid = linesToSay; //save previously said lines
             updateDialogue((List<string>)data); //update linesToSay
             startDialogue();
@@ -57,9 +59,12 @@ public class MichaelDialoguePanel : MonoBehaviour
 
     public void OnNpcNothingToDo(Component sender, object data)
     {
-        Debug.Log("inside onnpcnothingtodo");
-        linesToSay = linesDoNothing;
-        startDialogue();
+        if (!inDialogue)
+        {
+            inDialogue = true;
+            linesToSay = linesDoNothing;
+            startDialogue();
+        }
     }
 
     public void OnQuestFinalized(Component sender, object data)
@@ -112,6 +117,8 @@ public class MichaelDialoguePanel : MonoBehaviour
                 }
             }
         }
+        inDialogue = false;
+
         dialogueTM.text = "";
 
         leaveCutscene.Raise();

--- a/OoO_Game/Assets/Scripts/enemies/abstract_enemy.cs
+++ b/OoO_Game/Assets/Scripts/enemies/abstract_enemy.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 
 public abstract class abstract_enemy : MonoBehaviour
 {
+    [SerializeField]
+    private GameEvent enemyKilled;
+
     public int health;
     public int speed;
     public Vector3 velocity;
@@ -54,6 +57,7 @@ public abstract class abstract_enemy : MonoBehaviour
 
         if (health <= 0)
         {
+            enemyKilled.Raise();
             Death();
         }
             

--- a/OoO_Game/Assets/Scripts/enemies/abstract_enemy.cs.meta
+++ b/OoO_Game/Assets/Scripts/enemies/abstract_enemy.cs.meta
@@ -4,6 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences:
+  - enemyKilled: {fileID: 11400000, guid: 714d4b3917f70ca48a66301973682efe, type: 2}
   - enemySprite: {instanceID: 0}
   - projectileEnemy: {instanceID: 0}
   - powerUp: {fileID: 9039695199777951410, guid: 23a53ee4e3244e849b4197d65a46c09d, type: 3}


### PR DESCRIPTION
Added a quest that gets unlocked at player level 1 (after completing inspect orb quest) where the player needs to kill any 5 enemies and then turn in the quest at the starting base.

Mostly fixed the npc dialogue so now it doesn't freeze the game or create two dialogue coroutines anymore. It still happens occasionally and the game will need to be rebooted in that case.

Removed some unnecessary code that handled player positioning. Portals handle the player positioning already. I made it so that you go from starting base scene to level1 scene until we can figure out how to fix the tutorial level or if we can't fix it in time it is better to leave the tutorial out probably. 